### PR TITLE
Update package.json

### DIFF
--- a/chapter-2/fake-music-player/package.json
+++ b/chapter-2/fake-music-player/package.json
@@ -2,8 +2,8 @@
   "main": "node_modules/expo/AppEntry.js",
   "private": true,
   "dependencies": {
-    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz",
-    "expo": "^32.0.0",
-    "react": "16.5.0"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "expo": "~36.0.0",
+    "react": "~16.9.0"
   }
 }


### PR DESCRIPTION
this fixes the error: 'SDK 32.0.0 is not valid SDK Version'.
You might want to apply it to other packages as well.